### PR TITLE
prevent rendering if readme is changed

### DIFF
--- a/packages/neoFrontend/src/pages/VizPage/RunContext/changesJS.js
+++ b/packages/neoFrontend/src/pages/VizPage/RunContext/changesJS.js
@@ -1,28 +1,5 @@
-import { getExtension } from '../../../accessors';
+import { createChangesChecker } from './createChangesChecker';
 
 // Returns true if the given op changes a .js file
 // that is not bundle.js.
-export const changesJS = (op, previousFiles) => {
-  for (let i = 0; i < op.length; i++) {
-    const c = op[i];
-    if (c.p[0] === 'files') {
-      const fileIndex = c.p[1];
-
-      // If a file's content was changed, or a file was deleted.
-      if (c.si || c.sd || c.ld) {
-        const fileName = previousFiles[fileIndex].name;
-
-        // Ignore when bundle.js updates
-        if (fileName === 'bundle.js') {
-          continue;
-        }
-
-        const extension = getExtension(fileName);
-        if (extension === '.js') {
-          return true;
-        }
-      }
-    }
-  }
-  return false;
-};
+export const changesJS = createChangesChecker('.js');

--- a/packages/neoFrontend/src/pages/VizPage/RunContext/changesMD.js
+++ b/packages/neoFrontend/src/pages/VizPage/RunContext/changesMD.js
@@ -1,0 +1,5 @@
+import { createChangesChecker } from './createChangesChecker';
+
+// Returns true if the given op changes a .md file
+// that is not bundle.js.
+export const changesMD = createChangesChecker('.md');

--- a/packages/neoFrontend/src/pages/VizPage/RunContext/createChangesChecker.js
+++ b/packages/neoFrontend/src/pages/VizPage/RunContext/createChangesChecker.js
@@ -1,0 +1,33 @@
+import { getExtension } from '../../../accessors';
+
+export const createChangesChecker = (
+  targetExtension,
+  ignoreFiles = ['bundle.js']
+) => {
+  // Returns true if the given op changes a .[targetExtension] file
+  // that is not one of ignored files
+  return (op, previousFiles) => {
+    for (let i = 0; i < op.length; i++) {
+      const c = op[i];
+      if (c.p[0] === 'files') {
+        const fileIndex = c.p[1];
+
+        // If a file's content was changed, or a file was deleted.
+        if (c.si || c.sd || c.ld) {
+          const fileName = previousFiles[fileIndex].name;
+
+          // Ignore when ignored file updates
+          if (!!ignoreFiles.find(file => file === fileName)) {
+            continue;
+          }
+
+          const extension = getExtension(fileName);
+          if (extension === targetExtension) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  };
+};

--- a/packages/neoFrontend/src/pages/VizPage/RunContext/index.js
+++ b/packages/neoFrontend/src/pages/VizPage/RunContext/index.js
@@ -5,6 +5,6 @@ export const RunContext = createContext();
 
 // This context is responsible for figuring out when to re-run the code,
 // and when to recompute and store bundle.js.
-export const RunProvider = ({ fallback, children }) => (
+export const RunProvider = ({ children }) => (
   <RunContext.Provider value={useRun()}>{children}</RunContext.Provider>
 );

--- a/packages/neoFrontend/src/pages/VizPage/VizContext/index.js
+++ b/packages/neoFrontend/src/pages/VizPage/VizContext/index.js
@@ -4,7 +4,7 @@ import { useViz } from './useViz';
 
 export const VizContext = createContext();
 
-export const VizProvider = ({ fallback, children }) => {
+export const VizProvider = ({ children }) => {
   const vizPageData = useContext(VizPageDataContext);
   const contextValue = useViz(vizPageData.visualization);
 

--- a/packages/neoFrontend/src/pages/VizPage/VizRunnerContext/index.js
+++ b/packages/neoFrontend/src/pages/VizPage/VizRunnerContext/index.js
@@ -83,6 +83,7 @@ export const VizRunnerProvider = ({ children }) => {
       if (clearConsole) {
         console.clear();
       }
+
       iFrame.setAttribute(
         'srcDoc',
         computeSrcDoc(getVizFiles(viz$.getValue()))


### PR DESCRIPTION
The solution is based on active file name.
Theoretically, it is possible that user might change file during update, so re-run will be completed.
But I assumed that the chance of this event is low, and it is non-obvious user flow.
To avoid that case, it seems that, VizRunner component should know and keep track any change that looks as much more complicated solution.  