### PR TITLE
Don't show full top bar on mobile.

### DIFF
--- a/packages/neoFrontend/src/pages/VizPage/Body/Editor/CodeEditor/CodeEditorHeader/index.js
+++ b/packages/neoFrontend/src/pages/VizPage/Body/Editor/CodeEditor/CodeEditorHeader/index.js
@@ -33,13 +33,15 @@ export const CodeEditorHeader = ({
       {activeFile}
     </Text>
     <Icons>
-      <CodeEditorIcon
-        onClick={toggleShowTop}
-        leftmost={true}
-        title={showTop ? 'Hide top bar' : 'Show top bar'}
-      >
-        <ArrowSVG height={svgHeight} up={showTop} down={!showTop} />
-      </CodeEditorIcon>
+      {!isMobile ? (
+        <CodeEditorIcon
+          onClick={toggleShowTop}
+          leftmost={true}
+          title={showTop ? 'Hide top bar' : 'Show top bar'}
+        >
+          <ArrowSVG height={svgHeight} up={showTop} down={!showTop} />
+        </CodeEditorIcon>
+      ) : null}
       {viewer ? (
         <>
           <CodeEditorIcon


### PR DESCRIPTION
Before (that up arrow, when clicked, put the UI into a broken state):

![image](https://user-images.githubusercontent.com/68416/84516842-5fc76480-ac9c-11ea-802b-67fd986fe5ec.png)

After:

![image](https://user-images.githubusercontent.com/68416/84516904-7c639c80-ac9c-11ea-97e0-cecd8f47f0de.png)

Closes https://github.com/datavis-tech/vizhub-issue-tracker/issues/247