### PR TITLE
Fall Back to Username in User Search Results

### DIFF
--- a/packages/neoFrontend/package.json
+++ b/packages/neoFrontend/package.json
@@ -11,6 +11,7 @@
     "test-no-ci": "react-scripts test"
   },
   "proxy": "http://localhost:4000/",
+  "//proxy": "https://vizhub.com/",
   "author": "Datavis Tech INC",
   "license": "UNLICENSED",
   "dependencies": {

--- a/packages/neoFrontend/src/UserPreviewList/index.js
+++ b/packages/neoFrontend/src/UserPreviewList/index.js
@@ -1,4 +1,5 @@
 import React, { useMemo, useState, useEffect, useCallback } from 'react';
+import { getUserName, getUserFullName } from 'vizhub-presenters';
 import { BehaviorSubject } from 'rxjs';
 import { switchMap, debounceTime, tap } from 'rxjs/operators';
 import { Avatar } from '../Avatar';
@@ -19,6 +20,7 @@ export const UserPreviewList = ({
   onSelect,
 }) => {
   const typedText$ = useMemo(() => new BehaviorSubject(), []);
+
   useEffect(() => {
     if (query) {
       typedText$.next(query);
@@ -27,6 +29,7 @@ export const UserPreviewList = ({
   }, [typedText$, query]);
 
   const [results, setResults] = useState([]);
+
   const results$ = useMemo(() => {
     const operators = [debounceTime(debounceTimeMS), switchMap(fetchData)];
     if (onBeforeShowSuggestions) {
@@ -34,6 +37,7 @@ export const UserPreviewList = ({
     }
     return typedText$.pipe(...operators);
   }, [onBeforeShowSuggestions, typedText$]);
+
   useEffect(() => {
     const subscription = results$.subscribe(setResults);
     return () => subscription.unsubscribe();
@@ -51,9 +55,9 @@ export const UserPreviewList = ({
     <Container>
       {results &&
         results.map((user) => (
-          <UserPreview key={user.userName} onClick={() => handleClick(user)}>
+          <UserPreview key={getUserName(user)} onClick={() => handleClick(user)}>
             <Avatar size={24} user={user} isDisabled={true} />
-            <UserName>{user.fullName}</UserName>
+            <UserName>{getUserFullName(user)}</UserName>
           </UserPreview>
         ))}
     </Container>

--- a/packages/presenters/src/accessors.js
+++ b/packages/presenters/src/accessors.js
@@ -182,6 +182,9 @@ export const upvoteOp = (userId, upvotes) => {
 };
 
 export const getUserName = (user) => user && user.userName;
+
+// Return the full name of the user, for labeling.
+// Falls back to userName if fullName not present.
 export const getUserFullName = (user) =>
   user && (user.fullName || user.userName);
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/68416/85205036-831a9100-b2e6-11ea-8bbf-c39f940c19b2.png)

After:

![image](https://user-images.githubusercontent.com/68416/85205042-8a419f00-b2e6-11ea-8599-8e5da13e6263.png)

Applies to both user search and collaborator add search.