### PR TITLE
Move where forks count is presented

### DIFF
--- a/packages/neoFrontend/package.json
+++ b/packages/neoFrontend/package.json
@@ -20,6 +20,7 @@
     "color-hash": "^1.0.3",
     "copy-to-clipboard": "^3.3.1",
     "d3-color": "^1.4.1",
+    "d3-format": "^1.4.4",
     "d3-shape": "^1.3.7",
     "diff-match-patch": "^1.0.4",
     "immer": "^6.0.5",

--- a/packages/neoFrontend/src/UserPreviewList/index.js
+++ b/packages/neoFrontend/src/UserPreviewList/index.js
@@ -55,7 +55,10 @@ export const UserPreviewList = ({
     <Container>
       {results &&
         results.map((user) => (
-          <UserPreview key={getUserName(user)} onClick={() => handleClick(user)}>
+          <UserPreview
+            key={getUserName(user)}
+            onClick={() => handleClick(user)}
+          >
             <Avatar size={24} user={user} isDisabled={true} />
             <UserName>{getUserFullName(user)}</UserName>
           </UserPreview>

--- a/packages/neoFrontend/src/pages/HomePage/Banner/styles.js
+++ b/packages/neoFrontend/src/pages/HomePage/Banner/styles.js
@@ -11,7 +11,7 @@ export const Wrapper = styled.div`
   justify-content: space-around;
   align-items: center;
   color: white;
-  margin: ${isMobile ? '6px 6px 30px 6px' : 0}
+  margin: ${isMobile ? '6px 6px 30px 6px' : 0};
 `;
 
 export const Bar = styled.div`

--- a/packages/neoFrontend/src/pages/VizPage/Body/Head/index.js
+++ b/packages/neoFrontend/src/pages/VizPage/Body/Head/index.js
@@ -1,5 +1,5 @@
 import React, { useContext, useCallback } from 'react';
-import { getVizOwner, getVizForksCount } from 'vizhub-presenters';
+import { getVizOwner } from 'vizhub-presenters';
 import { ForkSVG, PullSVG, SettingsSVG, ShareSVG } from '../../../../svg';
 import { showHeadPullRequest, showHeadShare } from '../../../../featureFlags';
 import { useValue } from '../../../../useValue';
@@ -11,7 +11,7 @@ import { VizContext } from '../../VizContext';
 import { SettingsContext } from '../../SettingsContext';
 import { ShareContext } from '../../ShareContext';
 
-import { Wrapper, Left, Center, Right, HeadIcon, Counter } from './styles';
+import { Wrapper, Left, Center, Right, HeadIcon } from './styles';
 import { EditorToggler } from './EditorToggler';
 import { TrashIcon } from '../TrashIcon';
 
@@ -24,7 +24,6 @@ export const Head = ({ showRight }) => {
   const showSettingsModal = useContext(SettingsContext);
   const showShareModal = useContext(ShareContext);
   const owner = useValue(viz$, getVizOwner);
-  const forksCount = useValue(viz$, getVizForksCount);
 
   const showHeadTrash = me && me.id === owner;
   const showHeadSettings = showHeadTrash;
@@ -71,7 +70,6 @@ export const Head = ({ showRight }) => {
             rightmost={!showHeadTrash}
           >
             <ForkSVG />
-            {forksCount > 0 && <Counter>{forksCount}</Counter> }
           </HeadIcon>
           {showHeadTrash ? (
             <TrashIcon

--- a/packages/neoFrontend/src/pages/VizPage/Body/Head/styles.js
+++ b/packages/neoFrontend/src/pages/VizPage/Body/Head/styles.js
@@ -35,8 +35,3 @@ export const HeadIcon = styled(Icon)`
   width: 35px;
   margin-right: ${(props) => (props.rightmost ? 9 : 0)}px;
 `;
-
-export const Counter = styled.span`
-  padding-left: 3px;
-  font-size: 20px;
-`;

--- a/packages/neoFrontend/src/pages/VizPage/Body/Viewer/DescriptionSection/index.js
+++ b/packages/neoFrontend/src/pages/VizPage/Body/Viewer/DescriptionSection/index.js
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { format } from 'd3-format';
 import { toDate } from 'vizhub-entities';
 import {
   showCreatedDate,
@@ -26,6 +27,8 @@ const formatTimestamp = (timestamp) =>
     day: 'numeric',
   });
 
+const formatForksCount = format(',');
+
 export const DescriptionSection = ({
   vizInfo,
   ownerUser,
@@ -35,6 +38,11 @@ export const DescriptionSection = ({
 }) => {
   const created = useMemo(() => formatTimestamp(vizInfo.createdTimestamp), [
     vizInfo.createdTimestamp,
+  ]);
+
+  const forksCount = vizInfo.forksCount;
+  const forksCountFormatted = useMemo(() => formatForksCount(forksCount), [
+    forksCount,
   ]);
 
   const lastUpdated = useMemo(
@@ -66,6 +74,9 @@ export const DescriptionSection = ({
                 {showCreatedDate ? <> {created}</> : null}
               </div>
             ) : null}
+            <div>
+              {forksCountFormatted} fork{forksCount === 1 ? '' : 's'}
+            </div>
           </AuthorshipMeta>
         </Authorship>
         <Description

--- a/packages/neoFrontend/src/pages/VizPage/URLStateContext/reducer.js
+++ b/packages/neoFrontend/src/pages/VizPage/URLStateContext/reducer.js
@@ -22,7 +22,7 @@ export const reducer = (state, action) => {
           state.edit || state.edit === null
             ? Object.assign({}, state.hidden, { edit: state.edit })
             : state.hidden,
-        file: isMobile ? null : state.file
+        file: isMobile ? null : state.file,
       });
 
     case 'enterMini':


### PR DESCRIPTION
With some additional design consideration, moved where forks count is presented.

Also added comma formatter, to handle forks count larger than 1000.

![image](https://user-images.githubusercontent.com/68416/85230076-a3684f80-b3bb-11ea-93f6-09879b66371c.png)

Also, incidental changes due to Prettier.