### PR TITLE
Fix NaN forks count bug

### DIFF
--- a/packages/neoFrontend/src/pages/VizPage/Body/Viewer/DescriptionSection/index.js
+++ b/packages/neoFrontend/src/pages/VizPage/Body/Viewer/DescriptionSection/index.js
@@ -1,6 +1,7 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useContext } from 'react';
 import { format } from 'd3-format';
 import { toDate } from 'vizhub-entities';
+import { VizPageDataContext } from '../../../VizPageDataContext';
 import {
   showCreatedDate,
   showVideoThumbnail,
@@ -40,7 +41,12 @@ export const DescriptionSection = ({
     vizInfo.createdTimestamp,
   ]);
 
-  const forksCount = vizInfo.forksCount;
+  // Forks count is only present in the initial payload from the API.
+  // The field is not present in the ShareDB document,
+  // so we need to access it like this.
+  const vizPageData = useContext(VizPageDataContext);
+  const forksCount = vizPageData.visualization.info.forksCount;
+
   const forksCountFormatted = useMemo(() => formatForksCount(forksCount), [
     forksCount,
   ]);


### PR DESCRIPTION
Bug: after any change to the ShareDB document (such as upvoting), the `forksCount` field was disappearing, showing as `NaN`.

Solution: use only the initial API response, not the ShareDB document, for rendering forks count.
