### PR TITLE
Temporarily disable sort and forks count

### DIFF
--- a/packages/neoFrontend/src/featureFlags.js
+++ b/packages/neoFrontend/src/featureFlags.js
@@ -14,6 +14,8 @@ export const showVisualEditor = false;
 export const showMobileConsole = false;
 export const renameFileWithoutPath = false;
 export const showEmbed = false;
+export const showSortOptions = false;
+export const showForksCount = false;
 
 // List of usernames who have access to
 // private viz feature.

--- a/packages/neoFrontend/src/pages/HomePage/index.js
+++ b/packages/neoFrontend/src/pages/HomePage/index.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { showSortOptions } from '../../featureFlags';
 import { LoadingScreen } from '../../LoadingScreen';
 import { Wrapper, Content, Centering } from '../styles';
 import { HomePageDataProvider } from './HomePageDataContext';
@@ -16,7 +17,7 @@ export const HomePage = () => {
         <Content>
           <NavBar isHomePage={true} showSearch />
           <Banner />
-          <Sort value={sort} onChange={setSort} />
+          {showSortOptions ? <Sort value={sort} onChange={setSort} /> : null}
           <Centering>
             <Vizzes />
           </Centering>

--- a/packages/neoFrontend/src/pages/VizPage/Body/Viewer/DescriptionSection/index.js
+++ b/packages/neoFrontend/src/pages/VizPage/Body/Viewer/DescriptionSection/index.js
@@ -67,7 +67,7 @@ export const DescriptionSection = ({
                 {showCreatedDate ? <> {created}</> : null}
               </div>
             ) : null}
-            <Forks ownerUser={ownerUser} />
+            {showForksCount ? <Forks ownerUser={ownerUser} /> : null}
           </AuthorshipMeta>
         </Authorship>
         <Description


### PR DESCRIPTION
Behind feature flags, until the database migration happens to backfill forks count values.
So that I can deploy all other new changes to production.