### PR TITLE
Fix/ci puppeteer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,6 @@ executors:
     environment:
       NODE_ENV: development
 
-orbs:
-  puppeteer: threetreeslight/puppeteer@0.1.2
-
 jobs:
   build:
     executor: node_exec
@@ -33,7 +30,6 @@ jobs:
     executor: node_browsers
     steps:
       - checkout
-      - puppeteer/install
       - run: npm i lerna
       - run: npm install wait-on
       - run: npm run lerna:bootstrap

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,11 @@ executors:
   node_browsers:
     docker:
       - image: 'circleci/node:latest-browsers'
+    environment:
+      NODE_ENV: development
+
+orbs:
+  puppeteer: threetreeslight/puppeteer@0.1.2
 
 jobs:
   build:
@@ -28,13 +33,16 @@ jobs:
     executor: node_browsers
     steps:
       - checkout
-      - run: npm i
+      - puppeteer/install
+      - run: npm i lerna
+      - run: npm install wait-on
       - run: npm run lerna:bootstrap
       - run:
           name: Start Server
           command: npm run start:ci
           background: true
-      - run: npm run lerna:test:e2e
+      - run: npx wait-on http://localhost:3000
+      - run: npm run test:e2e
 
 workflows:
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,10 @@ executors:
     docker:
       - image: 'circleci/node:latest'
 
+  node_browsers:
+    docker:
+      - image: 'circleci/node:latest-browsers'
+
 jobs:
   build:
     executor: node_exec
@@ -20,8 +24,23 @@ jobs:
       - run: npm run lerna:bootstrap
       - run: npm run lerna:test
 
+  e2e:
+    executor: node_browsers
+    steps:
+      - checkout
+      - run: npm i
+      - run: npm run lerna:bootstrap
+      - run:
+          name: Start Server
+          command: npm run start:ci
+          background: true
+      - run: npm run lerna:test:e2e
+
 workflows:
   build_and_test:
     jobs:
       - build
       - test
+  e2e:
+    jobs:
+      - e2e

--- a/package.json
+++ b/package.json
@@ -1,13 +1,12 @@
 {
   "scripts": {
-		"lerna:bootstrap": "lerna bootstrap --hoist",
+    "lerna:bootstrap": "lerna bootstrap --hoist",
     "lerna:test": "lerna run test",
+    "lerna:start:ci": "lerna run start:ci",
+    "start:ci": "cd packages/neoFrontend && npm run start:ci",
+    "lerna:test:e2e": "lerna run test:e2e",
     "lint": "eslint . --fix",
-    "test": "cd packages/entities && npm test && cd ../useCases && npm test && cd ../gateways && npm test && cd ../presenters && npm test && cd ../controllers && npm test && cd ../database && npm test && echo 'All tests pass!'",
     "testAll": "npm run test && cd packages/web && npm test",
-    "startServer": "cd packages/web; npm run --silent dev &",
-    "stopServer": "kill $(lsof -t -i:3000)",
-    "ci": "lerna bootstrap && npm run startServer && npm run testAll && npm run stopServer",
     "updateDeps": "ncu -u; cd packages/entities && ncu -u && cd ../useCases && ncu -u cd ../gateways && ncu -u && cd ../presenters && ncu -u && cd ../controllers && ncu -u && cd ../database && ncu -u && cd ../web && ncu -u && cd ../ui && ncu -u && echo 'All dependencies upgraded!'",
     "cleanLockFiles": "find . -type f -name '*package-lock.json' -delete",
     "prettier": "cd packages/neoFrontend && npm run prettier && cd ../neoBackend && npm run prettier"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "lerna:test": "lerna run test",
     "lerna:start:ci": "lerna run start:ci",
     "start:ci": "cd packages/neoFrontend && npm run start:ci",
+    "test:e2e": "cd packages/neoCI && npm run test:e2e",
     "lerna:test:e2e": "lerna run test:e2e",
     "lint": "eslint . --fix",
     "testAll": "npm run test && cd packages/web && npm test",

--- a/packages/neoCI/package.json
+++ b/packages/neoCI/package.json
@@ -2,7 +2,7 @@
   "name": "vizhub-ci",
   "private": true,
   "scripts": {
-    "test-no-ci": "mocha -r esm --timeout 10000",
+    "test:e2e": "mocha -r esm --timeout 1",
     "prettier": "prettier --single-quote --write 'test/**/*.js'",
     "lint": "eslint test -c ./.eslintrc.js --no-eslintrc --fix"
   },

--- a/packages/neoCI/package.json
+++ b/packages/neoCI/package.json
@@ -2,7 +2,7 @@
   "name": "vizhub-ci",
   "private": true,
   "scripts": {
-    "test:e2e": "mocha -r esm --timeout 1",
+    "test:e2e": "mocha -r esm --timeout 10000",
     "prettier": "prettier --single-quote --write 'test/**/*.js'",
     "lint": "eslint test -c ./.eslintrc.js --no-eslintrc --fix"
   },

--- a/packages/neoFrontend/package.json
+++ b/packages/neoFrontend/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "start": "react-scripts start",
-    "start:ci": "react-scripts start",
+    "start:ci": "node scripts/server.js",
     "build": "react-scripts build",
     "prettier": "prettier --single-quote --write 'src/**/*.js'",
     "test-no-ci": "react-scripts test"

--- a/packages/neoFrontend/package.json
+++ b/packages/neoFrontend/package.json
@@ -6,6 +6,7 @@
   "main": "index.js",
   "scripts": {
     "start": "react-scripts start",
+    "start:ci": "react-scripts start",
     "build": "react-scripts build",
     "prettier": "prettier --single-quote --write 'src/**/*.js'",
     "test-no-ci": "react-scripts test"

--- a/packages/neoFrontend/scripts/server.js
+++ b/packages/neoFrontend/scripts/server.js
@@ -1,0 +1,66 @@
+process.env.BABEL_ENV = 'development';
+process.env.NODE_ENV = 'development';
+
+const webpack = require('webpack');
+const WebpackDevServer = require('webpack-dev-server');
+const {
+  choosePort,
+  createCompiler,
+  prepareProxy,
+  prepareUrls,
+} = require('react-dev-utils/WebpackDevServerUtils');
+const configFactory = require('react-scripts/config/webpack.config');
+const createDevServerConfig = require('react-scripts/config/webpackDevServer.config');
+const paths = require('react-scripts/config/paths');
+
+const config = configFactory('development');
+const protocol = process.env.HTTPS === 'true' ? 'https' : 'http';
+const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 3000;
+const HOST = process.env.HOST || '0.0.0.0';
+const port = DEFAULT_PORT;
+
+const urls = prepareUrls(
+  protocol,
+  HOST,
+  DEFAULT_PORT,
+  paths.publicUrlOrPath.slice(0, -1)
+);
+
+const devSocket = {
+  warnings: warnings =>
+    devServer.sockWrite(devServer.sockets, 'warnings', warnings),
+  errors: errors =>
+    devServer.sockWrite(devServer.sockets, 'errors', errors),
+};
+
+const compiler = createCompiler({
+  appName: 'Test',
+  config,
+  devSocket,
+  urls,
+  useYarn: false,
+  useTypeScript: false,
+  tscCompileOnError: false,
+  webpack,
+});
+
+const proxySetting = require(paths.appPackageJson).proxy;
+const proxyConfig = prepareProxy(
+  proxySetting,
+  paths.appPublic,
+  paths.publicUrlOrPath
+);
+const serverConfig = createDevServerConfig(
+  proxyConfig,
+  urls.lanUrlForConfig
+);
+
+const devServer = new WebpackDevServer(compiler, serverConfig);
+// Launch WebpackDevServer.
+devServer.listen(port, HOST, err => {
+  if (err) {
+    return console.log(err);
+  }
+
+  console.log(`Starting the development server...at ${HOST}:${DEFAULT_PORT} \n`);
+});


### PR DESCRIPTION
## What does this PR do?

It adds E2E tests to CircleCI and therefore to the PR process.

### Related Issue
closes https://github.com/datavis-tech/vizhub-issue-tracker/issues/336

### Added

Added a new local server for CI because the default `react-script` server did not work
added `wait-for` to CI to wait for `localhost:3000` to be available

### Tests fail
It seems that the login is not available. at least my local run (of circleci) results in 
```
<div class="sc-fzqNqU gGWPoD test-user-navbar-section" data-test-is-authenticated="true"></div>
```

### ToDo
- [ ] evaluate if BE server needs to be started as well in (dev mode?)
- [ ] evaluate if we want to add a `TESTING` env for `NODE_ENV`