### PR TITLE
Refactor Button

### DIFF
--- a/packages/neoFrontend/src/Button/index.js
+++ b/packages/neoFrontend/src/Button/index.js
@@ -1,0 +1,54 @@
+import styled from 'styled-components';
+
+// Matrix (red, blue) X (normal, hover, active) X (outline, filled):
+const buttonColor = (props) =>
+  props.isRed ? props.theme.red : props.theme.blue;
+
+const hoverButtonColorOutline = (props) =>
+  props.isRed ? props.theme.redHover : props.theme.blueHover;
+const hoverButtonColorFilled = (props) =>
+  props.isRed ? props.theme.redHoverFilled : props.theme.blueHoverFilled;
+const hoverButtonColor = (props) =>
+  props.isFilled
+    ? hoverButtonColorFilled(props)
+    : hoverButtonColorOutline(props);
+
+const activeButtonColorOutline = (props) =>
+  props.isRed ? props.theme.redActive : props.theme.blueActive;
+const activeButtonColorFilled = (props) =>
+  props.isRed ? props.theme.redActiveFilled : props.theme.blueActiveFilled;
+
+const activeButtonColor = (props) =>
+  props.isFilled
+    ? activeButtonColorFilled(props)
+    : activeButtonColorOutline(props);
+
+export const Button = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  padding-right: 16px;
+  padding-left: 16px;
+  height: ${(props) => props.theme.buttonHeight};
+  border-radius: 6px;
+  border: solid 1px ${buttonColor};
+  font-size: 16px;
+  font-weight: 500;
+  color: ${(props) => (props.isFilled ? '#ffffff' : props.theme.dark)};
+  background-color: ${(props) =>
+    props.isFilled ? buttonColor(props) : 'transparent'};
+  text-decoration: none;
+
+  :hover {
+    background-color: ${hoverButtonColor};
+  }
+
+  :active {
+    background-color: ${activeButtonColor};
+  }
+
+  cursor: pointer;
+  user-select: none;
+  margin-left: 8px;
+`;

--- a/packages/neoFrontend/src/Feedback/styles.js
+++ b/packages/neoFrontend/src/Feedback/styles.js
@@ -1,9 +1,7 @@
 // Common styles used in multiple pages.
 import styled from 'styled-components';
 import { Z_WAY_ABOVE } from '../styles';
-
-// TODO move this
-import { Button } from '../pages/styles';
+import { Button } from '../Button';
 
 export const Wrapper = styled.div`
   position: fixed;

--- a/packages/neoFrontend/src/pages/AuthPage/index.js
+++ b/packages/neoFrontend/src/pages/AuthPage/index.js
@@ -1,16 +1,10 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { NavBar } from '../../NavBar';
-import {
-  Wrapper,
-  Content,
-  Title,
-  Button,
-  DevsOnly,
-  Centering,
-} from '../styles';
-import { Box, Octocat, Terms } from './styles';
+import { Button } from '../../Button';
 import { GITHUB_OAUTH_URL, CI_AUTH_PATH } from '../../authentication';
+import { Wrapper, Content, Title, DevsOnly, Centering } from '../styles';
+import { Box, Octocat, Terms } from './styles';
 
 export const AuthPage = () => {
   return (

--- a/packages/neoFrontend/src/pages/CreateVizPage/FromScratchSection.js
+++ b/packages/neoFrontend/src/pages/CreateVizPage/FromScratchSection.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Title, Button, DevsOnly } from '../styles';
+import { Button } from '../../Button';
+import { Title, DevsOnly } from '../styles';
 
 export const FromScratchSection = () =>
   process.env.NODE_ENV === 'development' ? (

--- a/packages/neoFrontend/src/pages/HomePage/Banner/styles.js
+++ b/packages/neoFrontend/src/pages/HomePage/Banner/styles.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
+import { Button } from '../../../Button';
 import { isMobile } from '../../../mobileMods';
 import { Z_BELOW } from '../../../styles';
-import { Button } from '../../styles';
 
 export const Wrapper = styled.div`
   display: flex;

--- a/packages/neoFrontend/src/pages/PricingPage/index.js
+++ b/packages/neoFrontend/src/pages/PricingPage/index.js
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import { NavBar } from '../../NavBar';
-import { Wrapper, Content, HorizontalRule, Button } from '../styles';
+import { Button } from '../../Button';
+import { Wrapper, Content, HorizontalRule } from '../styles';
 import {
   Table,
   Row,

--- a/packages/neoFrontend/src/pages/VizPage/Body/RecoveryModeBanner/index.js
+++ b/packages/neoFrontend/src/pages/VizPage/Body/RecoveryModeBanner/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Wrapper, Side, Message } from './styles';
-import { Button } from '../../../styles';
+import { Button } from '../../../../Button';
+
 export const RecoveryModeBanner = ({ exitRecoveryMode }) => (
   <Wrapper>
     <Side>

--- a/packages/neoFrontend/src/pages/VizPage/DeleteVizContext/index.js
+++ b/packages/neoFrontend/src/pages/VizPage/DeleteVizContext/index.js
@@ -1,7 +1,7 @@
 import React, { createContext } from 'react';
 import { withRouter } from 'react-router';
 import { Modal } from '../../../Modal';
-import { Button } from '../../styles';
+import { Button } from '../../../Button';
 import { useDeleteViz } from './useDeleteViz';
 
 export const DeleteVizContext = createContext();

--- a/packages/neoFrontend/src/pages/VizPage/SettingsContext/index.js
+++ b/packages/neoFrontend/src/pages/VizPage/SettingsContext/index.js
@@ -1,9 +1,8 @@
 import React, { createContext, useContext, useCallback } from 'react';
-import { Button } from '../../styles';
+import { Button } from '../../../Button';
 import { Modal } from '../../../Modal';
 import { AuthContext } from '../../../authentication/AuthContext';
 import { showPrivacySettings } from '../../../featureFlags';
-import { RadioButton } from '../RadioButton';
 import { HorizontalRule } from '../../styles';
 import {
   Dialog,
@@ -14,6 +13,7 @@ import {
   SectionDescription,
   Spacer,
 } from '../styles';
+import { RadioButton } from '../RadioButton';
 import { useSettings } from './useSettings';
 import { SetHeight } from './SetHeight';
 

--- a/packages/neoFrontend/src/pages/VizPage/ShareContext/CollaboratorsBody/Collaborator/index.js
+++ b/packages/neoFrontend/src/pages/VizPage/ShareContext/CollaboratorsBody/Collaborator/index.js
@@ -1,9 +1,9 @@
 import React, { useCallback } from 'react';
 import { Avatar } from '../../../../../Avatar';
+import { Button } from '../../../../../Button';
 import { fetchUser } from '../fetchUser';
-import { useCache } from './useCache';
-import { Button } from '../../../../styles';
 import { UserName } from '../styles';
+import { useCache } from './useCache';
 import { Wrapper, LoadingText, UserWrapper } from './styles';
 
 export const Collaborator = ({ collaborator, removeCollaborator, isLast }) => {

--- a/packages/neoFrontend/src/pages/VizPage/ShareContext/TextCopier.js
+++ b/packages/neoFrontend/src/pages/VizPage/ShareContext/TextCopier.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import copy from 'copy-to-clipboard';
-import { Button } from '../../styles';
+import { Button } from '../../../Button';
 import { Input } from '../../../Input';
 import { FormRow } from '../styles';
 

--- a/packages/neoFrontend/src/pages/VizPage/ShareContext/index.js
+++ b/packages/neoFrontend/src/pages/VizPage/ShareContext/index.js
@@ -1,8 +1,7 @@
 import React, { createContext, useState } from 'react';
 import { showEmbed, showCollaborators } from '../../../featureFlags';
-import { Button } from '../../styles';
+import { Button } from '../../../Button';
 import { Modal } from '../../../Modal';
-import { useShare } from './useShare';
 import {
   Dialog,
   DialogTitle,
@@ -10,6 +9,7 @@ import {
   Section,
   SectionTitle,
 } from '../styles';
+import { useShare } from './useShare';
 import { Tabs, Tab } from './Tabs';
 import { LinkBody } from './LinkBody';
 import { EmbedBody } from './EmbedBody';

--- a/packages/neoFrontend/src/pages/styles.js
+++ b/packages/neoFrontend/src/pages/styles.js
@@ -25,59 +25,6 @@ export const DevsOnly = styled.div`
   color: ${(props) => props.theme.attentionGrabber};
 `;
 
-// Matrix (red, blue) X (normal, hover, active) X (outline, filled):
-const buttonColor = (props) =>
-  props.isRed ? props.theme.red : props.theme.blue;
-
-const hoverButtonColorOutline = (props) =>
-  props.isRed ? props.theme.redHover : props.theme.blueHover;
-const hoverButtonColorFilled = (props) =>
-  props.isRed ? props.theme.redHoverFilled : props.theme.blueHoverFilled;
-const hoverButtonColor = (props) =>
-  props.isFilled
-    ? hoverButtonColorFilled(props)
-    : hoverButtonColorOutline(props);
-
-const activeButtonColorOutline = (props) =>
-  props.isRed ? props.theme.redActive : props.theme.blueActive;
-const activeButtonColorFilled = (props) =>
-  props.isRed ? props.theme.redActiveFilled : props.theme.blueActiveFilled;
-
-const activeButtonColor = (props) =>
-  props.isFilled
-    ? activeButtonColorFilled(props)
-    : activeButtonColorOutline(props);
-
-export const Button = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  padding-right: 16px;
-  padding-left: 16px;
-  height: ${(props) => props.theme.buttonHeight};
-  border-radius: 6px;
-  border: solid 1px ${buttonColor};
-  font-size: 16px;
-  font-weight: 500;
-  color: ${(props) => (props.isFilled ? '#ffffff' : props.theme.dark)};
-  background-color: ${(props) =>
-    props.isFilled ? buttonColor(props) : 'transparent'};
-  text-decoration: none;
-
-  :hover {
-    background-color: ${hoverButtonColor};
-  }
-
-  :active {
-    background-color: ${activeButtonColor};
-  }
-
-  cursor: pointer;
-  user-select: none;
-  margin-left: 8px;
-`;
-
 export const Centering = styled.div`
   display: flex;
   justify-content: center;


### PR DESCRIPTION
This PR just moves where `Button` is defined, so that the feedback component doesn't need to reach into the `pages` directory.

Anyway I've always found it difficult to locate the definition of `Button`, so this refactoring solves that as well.