### PR TITLE
WIP: Add scope to signInFlow

### DIFF
--- a/packages/neoFrontend/src/authentication/AuthContext/index.js
+++ b/packages/neoFrontend/src/authentication/AuthContext/index.js
@@ -38,12 +38,13 @@ export const AuthProvider = ({ children }) => {
     return () => (subscribed = false);
   }, []);
 
-  // TODO: How to upgrade this to pass scope?
-  // This works hardcoded:
-  //signIn: useCallback(signInFlow(setMe, ['repo']), [setMe]),
   const contextValue = {
     me,
     signIn: useCallback(signInFlow(setMe), [setMe]),
+    signInWithScopes: useCallback(
+      (scopes) => {
+        signInFlow(setMe, scopes)()
+    }, [setMe, signInFlow]),
     signOut: useCallback(signOutFlow(setMe), [setMe]),
   };
 

--- a/packages/neoFrontend/src/authentication/AuthContext/index.js
+++ b/packages/neoFrontend/src/authentication/AuthContext/index.js
@@ -38,6 +38,9 @@ export const AuthProvider = ({ children }) => {
     return () => (subscribed = false);
   }, []);
 
+  // TODO: How to upgrade this to pass scope?
+  // This works hardcoded:
+  //signIn: useCallback(signInFlow(setMe, ['repo']), [setMe]),
   const contextValue = {
     me,
     signIn: useCallback(signInFlow(setMe), [setMe]),

--- a/packages/neoFrontend/src/authentication/signInFlow/index.js
+++ b/packages/neoFrontend/src/authentication/signInFlow/index.js
@@ -3,9 +3,9 @@ import { listenForMe } from './listenForMe';
 import { AUTH_PENDING } from '../constants';
 
 // Implements a popup-based OAuth sign in flow.
-export const signInFlow = (setMe) => () => {
+export const signInFlow = (setMe, scopes) => () => {
   setMe(AUTH_PENDING);
-  const popup = openPopup();
+  const popup = openPopup(scopes);
   // TODO make this a Promise
   listenForMe((me) => {
     popup.close();

--- a/packages/neoFrontend/src/authentication/signInFlow/openPopup.js
+++ b/packages/neoFrontend/src/authentication/signInFlow/openPopup.js
@@ -1,5 +1,13 @@
 // Opens a popup window that uses OAuth to authenticate.
 // The popup ends up at the route /authenticated (see Authenticated.js).
-export const openPopup = () => {
-  return window.open('/auth', 'vithub-auth');
+export const openPopup = (scopes=[]) => {
+  let authUrl = '/auth';
+  if (scopes) {
+    if (scopes instanceof Array) {
+      authUrl = authUrl.concat('?scopes=', scopes.join(' '));
+    } else {
+      authUrl = authUrl.concat('?scopes=', scopes);
+    }
+  }
+  return window.open(authUrl, 'vizhub-auth');
 };

--- a/packages/neoFrontend/src/pages/AuthPage/index.js
+++ b/packages/neoFrontend/src/pages/AuthPage/index.js
@@ -6,8 +6,19 @@ import { Button } from '../../Button';
 import { GITHUB_OAUTH_URL, CI_AUTH_PATH } from '../../authentication';
 import { Wrapper, Content, Title, DevsOnly, Centering } from '../styles';
 import { Box, Octocat, Terms } from './styles';
+import queryString from 'query-string';
 
-export const AuthPage = () => {
+export const AuthPage = (req) => {
+  const { scopes } = queryString.parse(window.location.search);
+
+  let githubURL = GITHUB_OAUTH_URL;
+  if (scopes) {
+    if (scopes instanceof Array) {
+      githubURL = githubURL.concat('&scope=', scopes.join(' '));
+    } else {
+      githubURL = githubURL.concat('&scope=', scopes);
+    }
+  }
   return (
     <>
       <NavBar isAuthPage={true} />
@@ -23,7 +34,7 @@ export const AuthPage = () => {
                 height="120"
                 src="/images/GitHub-Mark-120px-plus.png"
               />
-              <a href={GITHUB_OAUTH_URL}>
+              <a href={githubURL}>
                 <Button>Sign in with GitHub</Button>
               </a>
               <Terms>

--- a/packages/neoFrontend/src/pages/VizPage/SettingsContext/index.js
+++ b/packages/neoFrontend/src/pages/VizPage/SettingsContext/index.js
@@ -31,7 +31,7 @@ export const SettingsProvider = ({ children }) => {
     vizInfo,
   } = useSettings();
 
-  const { me } = useContext(AuthContext);
+  const { me, signInWithScopes} = useContext(AuthContext);
 
   // Make it so hitting Enter in a text input
   // closes the modal (equivalent to hitting the "Done" button.
@@ -41,6 +41,13 @@ export const SettingsProvider = ({ children }) => {
       event.preventDefault();
     },
     [hideSettingsModal]
+  );
+  const onSignIn = useCallback(
+    (event) => {
+      signInWithScopes(['repo']);
+      event.preventDefault();
+    },
+    [signInWithScopes]
   );
 
   return (
@@ -87,6 +94,7 @@ export const SettingsProvider = ({ children }) => {
                 </SectionDescription>
                 <SetHeight height={vizHeight} setHeight={setVizHeight} />
               </Section>
+              <Button onClick={onSignIn}>Sign in</Button>
               <DialogButtons>
                 <Button isFilled onClick={hideSettingsModal}>
                   Done


### PR DESCRIPTION
Work in Progress commit on adding `scopes` to the github auth request.  I don't know how to upgrade `useCallback` to allow an optional `scope` parameter passed into `signInFlow` or how to pass that into `AuthContext`.  It works if I change:

```
signIn: useCallback(signInFlow(setMe), [setMe]),
```
to
```
signIn: useCallback(signInFlow(setMe, ['repo']), [setMe]),
```
