### PR TITLE
Fix unfurl

### DIFF
--- a/packages/controllers/src/sanitize.js
+++ b/packages/controllers/src/sanitize.js
@@ -1,4 +1,4 @@
 import stripHtml from 'string-strip-html';
 import sanitizeHTML from 'sanitize-html';
 
-export const sanitize = (str) => sanitizeHTML(stripHtml(str));
+export const sanitize = (str) => sanitizeHTML(stripHtml(str).result);


### PR DESCRIPTION
Fixes broken unfurl after dependency upgrade.

It was due to a breaking change in the API of https://www.npmjs.com/package/string-strip-html