### PR TITLE
prevent creating code mirror instance without file text

### DIFF
--- a/packages/neoFrontend/src/pages/VizPage/Body/Editor/CodeEditor/CodeArea/CodeAreaCodeMirror5/CodeMirrorReactBinding.js
+++ b/packages/neoFrontend/src/pages/VizPage/Body/Editor/CodeEditor/CodeArea/CodeAreaCodeMirror5/CodeMirrorReactBinding.js
@@ -71,14 +71,6 @@ export const CodeMirrorReactBinding = React.forwardRef(
 
       if (codeMirror) return;
 
-      // If the file does not exist at this point, it means that
-      // we are accessing a URL that has a file "open" that doesn't exist,
-      // either because it's been renamed or deleted.
-      // In this case, we bail out to avoid a crash.
-      if (!fileText) {
-        return;
-      }
-
       const { CodeMirror } = editorModules;
       const cm = new CodeMirror(wrapperRef.current, {
         value: fileText,

--- a/packages/neoFrontend/src/pages/VizPage/Body/Editor/CodeEditor/CodeArea/CodeAreaCodeMirror5/index.js
+++ b/packages/neoFrontend/src/pages/VizPage/Body/Editor/CodeEditor/CodeArea/CodeAreaCodeMirror5/index.js
@@ -92,6 +92,8 @@ export const CodeAreaCodeMirror5 = ({
   const fileText = useMemo(() => {
     const file = getVizFile(fileIndex)(viz$.getValue());
 
+    console.log(file);
+
     // If the file does not exist at this point, it means that
     // we are accessing a URL that has a file "open" that doesn't exist,
     // either because it's been renamed or deleted.
@@ -273,23 +275,25 @@ export const CodeAreaCodeMirror5 = ({
 
   return (
     <>
-      <CodeMirrorReactBinding
-        ref={setCodeMirror}
-        fileText={fileText}
-        fileName={activeFile}
-        selectedLines={selectedLines}
-        readonly={activeFile === 'bundle.js'}
-        keyMap={keyMap}
-        editorModules={editorModules}
-        highlightScrollStrategy={highlightScrollStrategy}
-        onGutterClick={handleGutterClick}
-        onLinkClick={onLinkClick}
-        onManualRun={manualRunRef.current}
-        onFileTextChange={handleFileTextChange}
-        onCursorActivity={resetRunTimer}
-        onCursorPositionChange={handleCursorPositionChange}
-        onToggleVimMode={toggleVimMode}
-      />
+      {fileText !== null && (
+        <CodeMirrorReactBinding
+          ref={setCodeMirror}
+          fileText={fileText}
+          fileName={activeFile}
+          selectedLines={selectedLines}
+          readonly={activeFile === 'bundle.js'}
+          keyMap={keyMap}
+          editorModules={editorModules}
+          highlightScrollStrategy={highlightScrollStrategy}
+          onGutterClick={handleGutterClick}
+          onLinkClick={onLinkClick}
+          onManualRun={manualRunRef.current}
+          onFileTextChange={handleFileTextChange}
+          onCursorActivity={resetRunTimer}
+          onCursorPositionChange={handleCursorPositionChange}
+          onToggleVimMode={toggleVimMode}
+        />
+      )}
       {!editorModules ? <LoadingScreen color={light} isChild={true} /> : null}
     </>
   );

--- a/packages/neoFrontend/src/pages/VizPage/Body/Editor/CodeEditor/CodeArea/CodeAreaCodeMirror5/index.js
+++ b/packages/neoFrontend/src/pages/VizPage/Body/Editor/CodeEditor/CodeArea/CodeAreaCodeMirror5/index.js
@@ -92,8 +92,6 @@ export const CodeAreaCodeMirror5 = ({
   const fileText = useMemo(() => {
     const file = getVizFile(fileIndex)(viz$.getValue());
 
-    console.log(file);
-
     // If the file does not exist at this point, it means that
     // we are accessing a URL that has a file "open" that doesn't exist,
     // either because it's been renamed or deleted.


### PR DESCRIPTION
empty file (empty js string) is valid file text

Closes datavis-tech/vizhub-issue-tracker/issues/572