### PR TITLE
Move page view analytics to server side, track more stuff

### DIFF
--- a/packages/controllers/src/serveHomePage.js
+++ b/packages/controllers/src/serveHomePage.js
@@ -1,3 +1,4 @@
+import { SendEvent } from 'vizhub-use-cases';
 import { servePage } from './servePage';
 
 const meta = {
@@ -8,10 +9,13 @@ const meta = {
   url: '/',
 };
 
-export const serveHomePage = (indexHTML) => {
+export const serveHomePage = (gateways, indexHTML) => {
+  const sendEvent = new SendEvent(gateways);
+  const servePageMiddleware = servePage(indexHTML, meta);
   return async (req, res) => {
-    const servePageMiddleware = servePage(indexHTML, meta);
-
+    sendEvent.execute({
+      eventIDs: ['event', 'event.pageview', 'event.pageview.home']
+    });
     return servePageMiddleware(req, res);
   };
 };

--- a/packages/controllers/src/serveVizPage.js
+++ b/packages/controllers/src/serveVizPage.js
@@ -1,4 +1,4 @@
-import { GetVisualization } from 'vizhub-use-cases';
+import { GetVisualization, SendEvent } from 'vizhub-use-cases';
 import { servePage } from './servePage';
 import { userIdFromReq } from './userIdFromReq';
 
@@ -7,6 +7,7 @@ export const visualizationRoute = ({ userName, id }) => `/${userName}/${id}`;
 
 export const serveVizPage = (gateways, indexHTML) => {
   const getVisualization = new GetVisualization(gateways);
+  const sendEvent = new SendEvent(gateways);
 
   return async (req, res) => {
     try {
@@ -18,8 +19,9 @@ export const serveVizPage = (gateways, indexHTML) => {
         visualization: {
           info: { title, description },
         },
-        ownerUser: { userName },
+        ownerUser,
       } = responseModel;
+      const { userName } = ownerUser;
 
       const meta = {
         title,
@@ -28,6 +30,16 @@ export const serveVizPage = (gateways, indexHTML) => {
         url: visualizationRoute({ userName, id }),
       };
       const servePageMiddleware = servePage(indexHTML, meta);
+
+      sendEvent.execute({
+        eventIDs: [
+          'event',
+          'event.pageview',
+          'event.pageview.viz',
+          `event.pageview.viz.author:${ownerUser.id}`,
+          `event.pageview.viz.author:${ownerUser.id}.viz:${id}`
+        ]
+      });
 
       return servePageMiddleware(req, res);
     } catch (error) {

--- a/packages/controllers/src/serveVizPage.js
+++ b/packages/controllers/src/serveVizPage.js
@@ -37,7 +37,7 @@ export const serveVizPage = (gateways, indexHTML) => {
           'event.pageview',
           'event.pageview.viz',
           `event.pageview.viz.author:${ownerUser.id}`,
-          `event.pageview.viz.author:${ownerUser.id}.viz:${id}`
+          `event.pageview.viz.viz:${id}`
         ]
       });
 

--- a/packages/database/test/test.js
+++ b/packages/database/test/test.js
@@ -25,18 +25,6 @@ describe('Database', () => {
     createdVisualizationId = id;
   });
 
-  it('should create a dataset', async () => {
-    const { slug } = await database.createDataset(dataset);
-    assert.equal(slug, dataset.info.slug);
-  });
-
-  it('should get a dataset', async () => {
-    const fetched = await database.getDataset({
-      slug: dataset.info.slug
-    });
-    assert.deepEqual(fetched, { dataset });
-  });
-
   it('should create a user', async () => {
     const userOut = await database.createUser(user);
     assert.deepEqual(userOut, user);

--- a/packages/neoBackend/src/serveFrontend.js
+++ b/packages/neoBackend/src/serveFrontend.js
@@ -29,5 +29,5 @@ export const serveFrontend = (app, gateways) => {
 
   app.get('/:userName/:vizId', serveVizPage(gateways, indexHTML));
 
-  app.get('*', serveHomePage(indexHTML));
+  app.get('*', serveHomePage(gateways, indexHTML));
 };

--- a/packages/neoFrontend/src/index.js
+++ b/packages/neoFrontend/src/index.js
@@ -1,10 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { App } from './App';
-import { sendEvent } from './sendEvent';
-
-// Track each page load as a page view.
-sendEvent(['event', 'event.pageview']);
 
 // A place to put feature previews and easter eggs.
 window.vizhub = {};

--- a/packages/neoFrontend/src/pages/VizHubStatsPage/index.js
+++ b/packages/neoFrontend/src/pages/VizHubStatsPage/index.js
@@ -8,7 +8,11 @@ export const VizHubStatsPage = () => {
 
   useEffect(() => {
     const getData = async () => {
-      const eventIDs = ['event.pageview'];
+      const eventIDs = [
+        'event.pageview',
+        'event.pageview.home',
+        'event.pageview.viz'
+      ];
       const response = await fetch('/api/event/get', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/packages/useCases/src/interactors/sendEvent.js
+++ b/packages/useCases/src/interactors/sendEvent.js
@@ -19,8 +19,11 @@ export class SendEvent {
       {}
     );
 
+    // Fall back to current date if no date was passed in.
+    const dateToUse = date || new Date();
+
     const newEventRecords = eventIDs.map((id) =>
-      increment(recordsByID[id] || { id }, date, maxEntries)
+      increment(recordsByID[id] || { id }, dateToUse, maxEntries)
     );
 
     return await this.eventRecordsGateway.setEventRecords(newEventRecords);


### PR DESCRIPTION
 * Moves page view tracking to server side, to reduce volume of network requests from the client.
 * Tracks more events (breaks down views by home page, viz page, author, and viz).