### PR TITLE
Iterate analytics

### DIFF
--- a/packages/controllers/src/serveHomePage.js
+++ b/packages/controllers/src/serveHomePage.js
@@ -1,4 +1,3 @@
-import { SendEvent } from 'vizhub-use-cases';
 import { servePage } from './servePage';
 
 const meta = {
@@ -10,12 +9,8 @@ const meta = {
 };
 
 export const serveHomePage = (gateways, indexHTML) => {
-  const sendEvent = new SendEvent(gateways);
   const servePageMiddleware = servePage(indexHTML, meta);
   return async (req, res) => {
-    sendEvent.execute({
-      eventIDs: ['event', 'event.pageview', 'event.pageview.home'],
-    });
     return servePageMiddleware(req, res);
   };
 };

--- a/packages/controllers/src/serveVizPage.js
+++ b/packages/controllers/src/serveVizPage.js
@@ -1,4 +1,4 @@
-import { GetVisualization, SendEvent } from 'vizhub-use-cases';
+import { GetVisualization } from 'vizhub-use-cases';
 import { servePage } from './servePage';
 import { userIdFromReq } from './userIdFromReq';
 
@@ -7,7 +7,6 @@ export const visualizationRoute = ({ userName, id }) => `/${userName}/${id}`;
 
 export const serveVizPage = (gateways, indexHTML) => {
   const getVisualization = new GetVisualization(gateways);
-  const sendEvent = new SendEvent(gateways);
 
   return async (req, res) => {
     try {
@@ -30,16 +29,6 @@ export const serveVizPage = (gateways, indexHTML) => {
         url: visualizationRoute({ userName, id }),
       };
       const servePageMiddleware = servePage(indexHTML, meta);
-
-      sendEvent.execute({
-        eventIDs: [
-          'event',
-          'event.pageview',
-          'event.pageview.viz',
-          `event.pageview.viz.author:${ownerUser.id}`,
-          `event.pageview.viz.viz:${id}`,
-        ],
-      });
 
       return servePageMiddleware(req, res);
     } catch (error) {

--- a/packages/neoFrontend/src/pages/ForksPage/index.js
+++ b/packages/neoFrontend/src/pages/ForksPage/index.js
@@ -1,6 +1,7 @@
-import React, { useCallback, useContext } from 'react';
+import React, { useEffect, useCallback, useContext } from 'react';
 import { Link } from 'react-router-dom';
 import { getVizInfoOwner, getUserName } from 'vizhub-presenters';
+import { sendEvent } from '../../sendEvent';
 import { LoadingScreen } from '../../LoadingScreen';
 import { Feedback } from '../../Feedback';
 import { NavBar } from '../../NavBar';
@@ -24,6 +25,18 @@ export const ForksPage = () => {
     pageData.usersById,
   ]);
 
+  useEffect(() => {
+    if (pageData && pageData.visualizationInfo) {
+      const vizId = pageData.visualizationInfo.id;
+      sendEvent([
+        'event',
+        'event.pageview',
+        'event.pageview.forks',
+        `event.pageview.forks.viz:${vizId}`,
+      ]);
+    }
+  }, [pageData]);
+
   if (pageData && pageData.error) {
     setError({
       message: 'Visualization not found.',
@@ -37,6 +50,7 @@ export const ForksPage = () => {
     const { id } = vizInfo;
     const owner = getVizInfoOwner(pageData.visualizationInfo);
     const ownerUser = getUser(owner);
+
     return (
       <>
         <NavBar />

--- a/packages/neoFrontend/src/pages/HomePage/index.js
+++ b/packages/neoFrontend/src/pages/HomePage/index.js
@@ -16,7 +16,6 @@ export const HomePage = () => {
   const [sort, handleSortChange] = useVizzesSort();
 
   useEffect(() => {
-    console.log('sending home page view events');
     sendEvent(['event', 'event.pageview', 'event.pageview.home']);
   }, []);
 

--- a/packages/neoFrontend/src/pages/HomePage/index.js
+++ b/packages/neoFrontend/src/pages/HomePage/index.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { sendEvent } from '../../sendEvent';
 import { showSortOptions } from '../../featureFlags';
 import { LoadingScreen } from '../../LoadingScreen';
 import { NavBar } from '../../NavBar';
@@ -13,6 +14,11 @@ import { HtmlStylesOverride } from './styles';
 
 export const HomePage = () => {
   const [sort, handleSortChange] = useVizzesSort();
+
+  useEffect(() => {
+    console.log('sending home page view events');
+    sendEvent(['event', 'event.pageview', 'event.pageview.home']);
+  }, []);
 
   return (
     <>

--- a/packages/neoFrontend/src/pages/PricingPage/index.js
+++ b/packages/neoFrontend/src/pages/PricingPage/index.js
@@ -1,5 +1,6 @@
-import React, { Fragment, useContext } from 'react';
+import React, { Fragment, useContext, useEffect } from 'react';
 
+import { sendEvent } from '../../sendEvent';
 import { NavBar } from '../../NavBar';
 import { Button } from '../../Button';
 import { Feedback } from '../../Feedback';
@@ -25,6 +26,15 @@ import { handleUpgradeClick } from './stripe';
 
 export const PricingPage = () => {
   const { me } = useContext(AuthContext);
+
+  useEffect(() => {
+    sendEvent([
+      'event',
+      'event.pageview',
+      'event.pageview.pricing',
+      `event.pageview.pricing.viewer:${me ? me.id : 'anonymous'}`,
+    ]);
+  }, [me]);
 
   return (
     <>

--- a/packages/neoFrontend/src/pages/PricingPage/index.js
+++ b/packages/neoFrontend/src/pages/PricingPage/index.js
@@ -27,14 +27,16 @@ import { handleUpgradeClick } from './stripe';
 export const PricingPage = () => {
   const { me } = useContext(AuthContext);
 
+  const viewer = (me && me.id) || 'anonymous';
+
   useEffect(() => {
     sendEvent([
       'event',
       'event.pageview',
       'event.pageview.pricing',
-      `event.pageview.pricing.viewer:${me ? me.id : 'anonymous'}`,
+      `event.pageview.pricing.viewer:${viewer}`,
     ]);
-  }, [me]);
+  }, [viewer]);
 
   return (
     <>

--- a/packages/neoFrontend/src/pages/ProfilePage/Body/index.js
+++ b/packages/neoFrontend/src/pages/ProfilePage/Body/index.js
@@ -1,6 +1,12 @@
-import React, { useState, useContext, useMemo, useCallback } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useContext,
+  useMemo,
+  useCallback,
+} from 'react';
 import { isVizInfoPrivate } from 'vizhub-presenters';
-
+import { sendEvent } from '../../../sendEvent';
 import { AuthContext } from '../../../authentication';
 import { showProfileSidebar } from '../../../featureFlags';
 import { showSortOptions } from '../../../featureFlags';
@@ -29,6 +35,15 @@ export const Body = () => {
   const { me } = useContext(AuthContext);
 
   const [privacy, setPrivacy] = useState('public');
+
+  useEffect(() => {
+    sendEvent([
+      'event',
+      'event.pageview',
+      'event.pageview.profile',
+      `event.pageview.profile.user:${user.id}`,
+    ]);
+  }, [user]);
 
   const visualizations = useMemo(
     () =>

--- a/packages/neoFrontend/src/pages/VizHubStatsPage/index.js
+++ b/packages/neoFrontend/src/pages/VizHubStatsPage/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { NavBar } from '../../NavBar';
-import { Wrapper, Content, CopyWrapper } from '../styles';
+import { Wrapper, Content } from '../styles';
 import { Stats } from './styles';
 
 export const VizHubStatsPage = () => {

--- a/packages/neoFrontend/src/pages/VizPage/Body/index.js
+++ b/packages/neoFrontend/src/pages/VizPage/Body/index.js
@@ -28,7 +28,7 @@ export const Body = () => {
       'event.pageview',
       'event.pageview.viz',
       `event.pageview.viz.owner:${ownerUser.id}`,
-      `event.pageview.viz.viz:${vizId}`,
+      `event.pageview.viz.owner:${ownerUser.id}.viz:${vizId}`,
     ]);
   }, [ownerUser.id, vizId]);
 

--- a/packages/neoFrontend/src/pages/VizPage/Body/index.js
+++ b/packages/neoFrontend/src/pages/VizPage/Body/index.js
@@ -1,5 +1,7 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
+import { sendEvent } from '../../../sendEvent';
 import { URLStateContext } from '../URLStateContext';
+import { VizPageDataContext } from '../VizPageDataContext';
 import { modes } from '../URLStateContext/modes';
 import { FullScreenModePresenter } from './FullScreenModePresenter';
 import { EmbedModePresenter } from './EmbedModePresenter';
@@ -17,7 +19,18 @@ const modePresentersMap = {
 };
 
 export const Body = () => {
-  const { mode } = useContext(URLStateContext);
+  const { mode, vizId } = useContext(URLStateContext);
+  const { ownerUser } = useContext(VizPageDataContext);
+
+  useEffect(() => {
+    sendEvent([
+      'event',
+      'event.pageview',
+      'event.pageview.viz',
+      `event.pageview.viz.owner:${ownerUser.id}`,
+      `event.pageview.viz.viz:${vizId}`,
+    ]);
+  }, [ownerUser.id, vizId]);
 
   const VizModePresenter = modePresentersMap[mode] || EditorModePresenter;
 

--- a/packages/neoFrontend/src/sendEvent.js
+++ b/packages/neoFrontend/src/sendEvent.js
@@ -1,4 +1,5 @@
 export const sendEvent = (eventIDs) => {
+  // console.log('sendEvent: ', eventIDs);
   fetch('/api/event/send', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
Moves event tracking 100% to client in order to solve a number of problems, including:
 * Server-side event tracking does not capture client-side navigations
 * Server-side event tracking counts non-browser hits (e.g. unfurl, Google indexing)

Adds event tracking to more pages.