### PR TITLE
Solve bundle size issue

### DIFF
--- a/packages/neoBackend/package.json
+++ b/packages/neoBackend/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "eslint": "^7.3.1",
     "esm": "^3.2.25",
+    "jsdom": "^16.4.0",
     "prettier": "^2.0.5"
   },
   "dependencies": {
@@ -29,6 +30,7 @@
     "vizhub-controllers": "1",
     "vizhub-database": "1",
     "vizhub-entities": "1",
+    "vizhub-presenters": "1",
     "vizhub-server-gateways": "1",
     "vizhub-use-cases": "1",
     "ws": "^7.3.0"

--- a/packages/neoBackend/src/index.js
+++ b/packages/neoBackend/src/index.js
@@ -5,8 +5,12 @@ import cookieParser from 'cookie-parser';
 import compression from 'compression';
 import { serverGateways } from 'vizhub-server-gateways';
 import { apiController, jwtAuth, oembedController } from 'vizhub-controllers';
+import { setJSDOM } from 'vizhub-presenters';
+import { JSDOM } from 'jsdom';
 import { serveFrontend } from './serveFrontend';
 import { serveShareDB } from './serveShareDB';
+
+setJSDOM(JSDOM);
 
 const expressApp = express();
 

--- a/packages/presenters/package.json
+++ b/packages/presenters/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "test": "mocha -r esm test/test.js",
-    "prettier": "prettier --single-quote --write 'src/**/*.js'",
+    "prettier": "prettier --single-quote --write '{src,test}/**/*.js'",
     "updateDeps": "ncu -u"
   },
   "author": "Curran Kelleher",

--- a/packages/presenters/src/getComputedIndexHtml.js
+++ b/packages/presenters/src/getComputedIndexHtml.js
@@ -9,26 +9,17 @@ import { isPackageJSONEnabled } from './featureFlags';
 const template = (files) => getText(files, 'index.html');
 const bundle = (files) => getText(files, 'bundle.js');
 
-// let parse;
-// if (typeof module !== 'undefined' && module.exports) {
-//   const jsdom = require('jsdom');
-//   const { JSDOM } = jsdom;
-
-//   parse = (template) => new JSDOM(template);
-// } else {
-//   parse = (template, mimeType) => new DOMParser().parseFromString(template, mimeType);
-// }
-
-// Dynamic require in a Node environment.
 let parser;
+
+// If we're in the browser, use native DOMParser.
 if (typeof window !== 'undefined') {
   parser = new DOMParser();
 }
 
-// Expose a way to inject a DOMParser implementation for
-// unit tests that run in Node.
-export const setParser = (newParser) => {
-  parser = newParser;
+// Expose a way to inject a DOMParser implementation
+// when we're in a Node environment (tests, API server).
+export const setJSDOM = (JSDOM) => {
+  parser = new new JSDOM().window.DOMParser();
 };
 
 const injectBundleScript = (htmlTemplate, files) => {

--- a/packages/presenters/src/getComputedIndexHtml.js
+++ b/packages/presenters/src/getComputedIndexHtml.js
@@ -21,12 +21,15 @@ const bundle = (files) => getText(files, 'bundle.js');
 
 // Dynamic require in a Node environment.
 let parser;
-if (typeof module !== 'undefined' && module.exports) {
-  const { JSDOM } = require('jsdom');
-  parser = new new JSDOM().window.DOMParser();
-} else {
+if (typeof window !== 'undefined') {
   parser = new DOMParser();
 }
+
+// Expose a way to inject a DOMParser implementation for
+// unit tests that run in Node.
+export const setParser = (newParser) => {
+  parser = newParser;
+};
 
 const injectBundleScript = (htmlTemplate, files) => {
   const doc = parser.parseFromString(htmlTemplate, 'text/html');

--- a/packages/presenters/src/index.js
+++ b/packages/presenters/src/index.js
@@ -3,6 +3,6 @@ export { DatasetViewModel } from './datasetViewModel';
 export { bundle } from './bundle';
 export { computeSrcDoc } from './computeSrcDoc';
 export { getLibraries } from './getLibraries';
-export { getComputedIndexHtml } from './getComputedIndexHtml';
+export { getComputedIndexHtml, setJSDOM } from './getComputedIndexHtml';
 export * from './accessors';
 export * from './packageJson';

--- a/packages/presenters/test/test.js
+++ b/packages/presenters/test/test.js
@@ -3,22 +3,25 @@ import { testData } from 'vizhub-entities';
 import { VisualizationViewModel, DatasetViewModel } from '../src';
 import { bundle } from '../src';
 import sinon from 'sinon';
+import { JSDOM } from 'jsdom';
+import { setParser } from '../src/getComputedIndexHtml';
+setParser(new new JSDOM().window.DOMParser());
 
-const {
-  visualization,
-  dataset
-} = testData;
+const { visualization, dataset } = testData;
 
-const removeSourceMap = files => {
+const removeSourceMap = (files) => {
   files[0].text = files[0].text.split('\n//# sourceMappingURL')[0];
   return files;
 };
 
-global.fetch = sinon.fake.resolves(
-  { ok: true, url: '',
-    text: () => Promise.resolve(
-      "const globals={};const noop={};const dispatch_dev={};const validate_slots={};const SvelteComponentDev={};const init={};const safe_not_equal={}; export { globals, noop, dispatch_dev, validate_slots, SvelteComponentDev, init, safe_not_equal }")
-  })
+global.fetch = sinon.fake.resolves({
+  ok: true,
+  url: '',
+  text: () =>
+    Promise.resolve(
+      'const globals={};const noop={};const dispatch_dev={};const validate_slots={};const SvelteComponentDev={};const init={};const safe_not_equal={}; export { globals, noop, dispatch_dev, validate_slots, SvelteComponentDev, init, safe_not_equal }'
+    ),
+});
 
 describe('Presenters', () => {
   describe('VisualizationViewModel', () => {
@@ -26,10 +29,10 @@ describe('Presenters', () => {
       assert.deepEqual(new VisualizationViewModel(visualization), {
         id: visualization.id,
         files: visualization.content.files,
-        title: "Foo",
-        description: "Foo the great",
+        title: 'Foo',
+        description: 'Foo the great',
         width: 960,
-        height: 600
+        height: 600,
       });
     });
   });
@@ -37,12 +40,12 @@ describe('Presenters', () => {
   describe('DatasetViewModel', () => {
     it('should present a Dataset', () => {
       assert.deepEqual(new DatasetViewModel(dataset), {
-        title: "Foo",
-        slug: "foo",
-        format: "csv",
-        sourceName: "Flaring Central",
-        sourceUrl: "https://flaring.central/",
-        text: "a,b,c\n1,2,3\n4,5,6"
+        title: 'Foo',
+        slug: 'foo',
+        format: 'csv',
+        sourceName: 'Flaring Central',
+        sourceUrl: 'https://flaring.central/',
+        text: 'a,b,c\n1,2,3\n4,5,6',
       });
     });
   });
@@ -50,85 +53,124 @@ describe('Presenters', () => {
   describe('Bundler', () => {
     it('should bundle files using Rollup', async () => {
       const files = [
-        { name: 'index.js', text: 'import { foo } from "./foo.js"; console.log(foo);' },
-        { name: 'foo.js', text: 'export const foo = "bar";' }
+        {
+          name: 'index.js',
+          text: 'import { foo } from "./foo.js"; console.log(foo);',
+        },
+        { name: 'foo.js', text: 'export const foo = "bar";' },
       ];
-      assert.deepEqual(removeSourceMap(await bundle(files)), [{
-        name: 'bundle.js',
-        text: "(function () {\n\t'use strict';\n\n\tconst foo = \"bar\";\n\n\tconsole.log(foo);\n\n}());\n"
-      }]);
+      assert.deepEqual(removeSourceMap(await bundle(files)), [
+        {
+          name: 'bundle.js',
+          text:
+            '(function () {\n\t\'use strict\';\n\n\tconst foo = "bar";\n\n\tconsole.log(foo);\n\n}());\n',
+        },
+      ]);
     });
 
     it('should refer to global d3 in bundle for d3 package', async () => {
       const files = [
-        { name: 'index.js', text: 'import { select } from "d3"; console.log(select);' }
+        {
+          name: 'index.js',
+          text: 'import { select } from "d3"; console.log(select);',
+        },
       ];
-      assert.deepEqual(removeSourceMap(await bundle(files)), [{
-        name: 'bundle.js',
-        text: "(function (d3) {\n\t'use strict';\n\n\tconsole.log(d3.select);\n\n}(d3));\n"
-      }]);
+      assert.deepEqual(removeSourceMap(await bundle(files)), [
+        {
+          name: 'bundle.js',
+          text:
+            "(function (d3) {\n\t'use strict';\n\n\tconsole.log(d3.select);\n\n}(d3));\n",
+        },
+      ]);
     });
 
     it('should refer to global React in bundle for React package', async () => {
       const files = [
-        { name: 'index.js', text: 'import React from "react"; console.log(React);' }
+        {
+          name: 'index.js',
+          text: 'import React from "react"; console.log(React);',
+        },
       ];
-      assert.deepEqual(removeSourceMap(await bundle(files)), [{
-        name: 'bundle.js',
-        text:"(function (React) {\n\t'use strict';\n\n\tReact = React && Object.prototype.hasOwnProperty.call(React, 'default') ? React['default'] : React;\n\n\tconsole.log(React);\n\n}(React));\n"
-      }]);
+      assert.deepEqual(removeSourceMap(await bundle(files)), [
+        {
+          name: 'bundle.js',
+          text:
+            "(function (React) {\n\t'use strict';\n\n\tReact = React && Object.prototype.hasOwnProperty.call(React, 'default') ? React['default'] : React;\n\n\tconsole.log(React);\n\n}(React));\n",
+        },
+      ]);
     });
 
     it('should transpile JSX', async () => {
-      const files = [
-        { name: 'index.js', text: '<div>Hello JSX!</div>' }
-      ];
-      assert.deepEqual(removeSourceMap(await bundle(files)), [{
-        name: 'bundle.js',
-        text: "(function () {\n\t'use strict';\n\n\tReact.createElement( 'div', null, \"Hello JSX!\" );\n\n}());\n"
-      }]);
+      const files = [{ name: 'index.js', text: '<div>Hello JSX!</div>' }];
+      assert.deepEqual(removeSourceMap(await bundle(files)), [
+        {
+          name: 'bundle.js',
+          text:
+            "(function () {\n\t'use strict';\n\n\tReact.createElement( 'div', null, \"Hello JSX!\" );\n\n}());\n",
+        },
+      ]);
     });
 
     it('should not transpile ES6', async () => {
       const files = [
-        { name: 'index.js', text: 'const fn = a => a * a; console.log(fn(4));' }
+        {
+          name: 'index.js',
+          text: 'const fn = a => a * a; console.log(fn(4));',
+        },
       ];
-      assert.deepEqual(removeSourceMap(await bundle(files)), [{
-        name: 'bundle.js',
-        text: "(function () {\n\t'use strict';\n\n\tconst fn = a => a * a; console.log(fn(4));\n\n}());\n"
-      }]);
+      assert.deepEqual(removeSourceMap(await bundle(files)), [
+        {
+          name: 'bundle.js',
+          text:
+            "(function () {\n\t'use strict';\n\n\tconst fn = a => a * a; console.log(fn(4));\n\n}());\n",
+        },
+      ]);
     });
 
     it('should allow generators', async () => {
       const files = [
-        { name: 'index.js', text: 'console.log(function* () { yield 5; }().next().value)' }
+        {
+          name: 'index.js',
+          text: 'console.log(function* () { yield 5; }().next().value)',
+        },
       ];
-      assert.deepEqual(removeSourceMap(await bundle(files)), [{
-        name: 'bundle.js',
-        text: "(function () {\n\t'use strict';\n\n\tconsole.log(function* () { yield 5; }().next().value);\n\n}());\n"
-      }]);
+      assert.deepEqual(removeSourceMap(await bundle(files)), [
+        {
+          name: 'bundle.js',
+          text:
+            "(function () {\n\t'use strict';\n\n\tconsole.log(function* () { yield 5; }().next().value);\n\n}());\n",
+        },
+      ]);
     });
 
     it('should allow characters outside of the Latin1 range', async () => {
-      const files = [
-        { name: 'index.js', text: 'console.log("Привет")' }
-      ];
-      assert.deepEqual(removeSourceMap(await bundle(files)), [{
-        name: 'bundle.js',
-        text: "(function () {\n\t'use strict';\n\n\tconsole.log(\"Привет\");\n\n}());\n"
-      }]);
+      const files = [{ name: 'index.js', text: 'console.log("Привет")' }];
+      assert.deepEqual(removeSourceMap(await bundle(files)), [
+        {
+          name: 'bundle.js',
+          text:
+            '(function () {\n\t\'use strict\';\n\n\tconsole.log("Привет");\n\n}());\n',
+        },
+      ]);
     });
   });
   describe('Svelte', () => {
     it('should bundle files using Rollup', async () => {
       const files = [
-        { name: 'index.js', text: "import App from './App.svelte'; const app = new App({ target: document.body, }); export default app;" },
+        {
+          name: 'index.js',
+          text:
+            "import App from './App.svelte'; const app = new App({ target: document.body, }); export default app;",
+        },
         { name: 'App.svelte', text: '<script>console.log(foo);</script>' },
       ];
-      assert.deepEqual(removeSourceMap(await bundle(files)), [{
-        name: 'bundle.js',
-        text: "var bundle = (function () {\n\t'use strict';\n\n\tconst globals={};const noop={};const dispatch_dev={};const validate_slots={};const SvelteComponentDev={};const init={};const safe_not_equal={};\n\n\t/* code.svelte generated by Svelte v3.31.0 */\n\n\tconst { console: console_1 } = globals;\n\n\tfunction create_fragment(ctx) {\n\t\tconst block = {\n\t\t\tc: noop,\n\t\t\tl: function claim(nodes) {\n\t\t\t\tthrow new Error(\"options.hydrate only works if the component was compiled with the `hydratable: true` option\");\n\t\t\t},\n\t\t\tm: noop,\n\t\t\tp: noop,\n\t\t\ti: noop,\n\t\t\to: noop,\n\t\t\td: noop\n\t\t};\n\n\t\tdispatch_dev(\"SvelteRegisterBlock\", {\n\t\t\tblock,\n\t\t\tid: create_fragment.name,\n\t\t\ttype: \"component\",\n\t\t\tsource: \"\",\n\t\t\tctx\n\t\t});\n\n\t\treturn block;\n\t}\n\n\tfunction instance($$self, $$props) {\n\t\tlet { $$slots: slots = {}, $$scope } = $$props;\n\t\tvalidate_slots(\"Code\", slots, []);\n\t\tconsole.log(foo);\n\t\tconst writable_props = [];\n\n\t\tObject.keys($$props).forEach(key => {\n\t\t\tif (!~writable_props.indexOf(key) && key.slice(0, 2) !== \"$$\") console_1.warn(`<Code> was created with unknown prop '${key}'`);\n\t\t});\n\n\t\treturn [];\n\t}\n\n\tclass Code extends SvelteComponentDev {\n\t\tconstructor(options) {\n\t\t\tsuper(options);\n\t\t\tinit(this, options, instance, create_fragment, safe_not_equal, {});\n\n\t\t\tdispatch_dev(\"SvelteRegisterComponent\", {\n\t\t\t\tcomponent: this,\n\t\t\t\ttagName: \"Code\",\n\t\t\t\toptions,\n\t\t\t\tid: create_fragment.name\n\t\t\t});\n\t\t}\n\t}\n\n\tconst app = new Code({ target: document.body, });\n\n\treturn app;\n\n}());\n"
-      }]);
+      assert.deepEqual(removeSourceMap(await bundle(files)), [
+        {
+          name: 'bundle.js',
+          text:
+            'var bundle = (function () {\n\t\'use strict\';\n\n\tconst globals={};const noop={};const dispatch_dev={};const validate_slots={};const SvelteComponentDev={};const init={};const safe_not_equal={};\n\n\t/* code.svelte generated by Svelte v3.31.0 */\n\n\tconst { console: console_1 } = globals;\n\n\tfunction create_fragment(ctx) {\n\t\tconst block = {\n\t\t\tc: noop,\n\t\t\tl: function claim(nodes) {\n\t\t\t\tthrow new Error("options.hydrate only works if the component was compiled with the `hydratable: true` option");\n\t\t\t},\n\t\t\tm: noop,\n\t\t\tp: noop,\n\t\t\ti: noop,\n\t\t\to: noop,\n\t\t\td: noop\n\t\t};\n\n\t\tdispatch_dev("SvelteRegisterBlock", {\n\t\t\tblock,\n\t\t\tid: create_fragment.name,\n\t\t\ttype: "component",\n\t\t\tsource: "",\n\t\t\tctx\n\t\t});\n\n\t\treturn block;\n\t}\n\n\tfunction instance($$self, $$props) {\n\t\tlet { $$slots: slots = {}, $$scope } = $$props;\n\t\tvalidate_slots("Code", slots, []);\n\t\tconsole.log(foo);\n\t\tconst writable_props = [];\n\n\t\tObject.keys($$props).forEach(key => {\n\t\t\tif (!~writable_props.indexOf(key) && key.slice(0, 2) !== "$$") console_1.warn(`<Code> was created with unknown prop \'${key}\'`);\n\t\t});\n\n\t\treturn [];\n\t}\n\n\tclass Code extends SvelteComponentDev {\n\t\tconstructor(options) {\n\t\t\tsuper(options);\n\t\t\tinit(this, options, instance, create_fragment, safe_not_equal, {});\n\n\t\t\tdispatch_dev("SvelteRegisterComponent", {\n\t\t\t\tcomponent: this,\n\t\t\t\ttagName: "Code",\n\t\t\t\toptions,\n\t\t\t\tid: create_fragment.name\n\t\t\t});\n\t\t}\n\t}\n\n\tconst app = new Code({ target: document.body, });\n\n\treturn app;\n\n}());\n',
+        },
+      ]);
     });
   });
 });

--- a/packages/presenters/test/test.js
+++ b/packages/presenters/test/test.js
@@ -1,11 +1,15 @@
 import assert from 'assert';
 import { testData } from 'vizhub-entities';
-import { VisualizationViewModel, DatasetViewModel } from '../src';
-import { bundle } from '../src';
-import sinon from 'sinon';
 import { JSDOM } from 'jsdom';
-import { setParser } from '../src/getComputedIndexHtml';
-setParser(new new JSDOM().window.DOMParser());
+import {
+  VisualizationViewModel,
+  DatasetViewModel,
+  bundle,
+  setJSDOM,
+} from '../src';
+import sinon from 'sinon';
+
+setJSDOM(JSDOM);
 
 const { visualization, dataset } = testData;
 


### PR DESCRIPTION
For some mysterious reason, JSDOM was being included in the production bundle.

This PR fixes the issue by only importong JSDOM in the unit test, and passing the reference into the module that needs DOMParser.

Also, run Prettier on the test.