### PR TITLE
Add create viz button to home page

### DIFF
--- a/packages/neoFrontend/src/pages/HomePage/Sort/index.js
+++ b/packages/neoFrontend/src/pages/HomePage/Sort/index.js
@@ -1,11 +1,17 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { VizzesSortForm } from '../../../VizzesGrid/VizzesSortForm';
+import { Button } from '../../../Button';
 import { Container, Header } from './styles';
 
 export const Sort = (props) => {
   return (
     <Container>
-      <Header>VizHub Community</Header>
+      <Header>
+        <Link to="/create-viz">
+          <Button>Create a Viz</Button>
+        </Link>
+      </Header>
       <VizzesSortForm {...props} />
     </Container>
   );


### PR DESCRIPTION
Replaces "VizHub Community" text with "Create a Viz" button.

![image](https://user-images.githubusercontent.com/68416/103413955-c5504500-4b49-11eb-8085-c12eca8076c6.png)

