### PR TITLE
Remove banner

### DIFF
--- a/vizhub-v2/packages/neoFrontend/src/NavBar/NeoNavBar/index.js
+++ b/vizhub-v2/packages/neoFrontend/src/NavBar/NeoNavBar/index.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { withTheme } from 'styled-components';
-import { showAboutLink, showPricing } from '../../featureFlags';
+import { showAboutLink } from '../../featureFlags';
 import { LogoSVG } from '../../svg';
 import { isMobile } from '../../mobileMods';
 import { AuthContext, AUTH_PENDING } from '../../authentication';
@@ -8,7 +8,7 @@ import { UserActionsMenu } from './UserActionsMenu';
 import { Search } from './Search';
 import { DesktopLayout } from './DesktopLayout';
 import { MobileLayout } from './MobileLayout';
-import { NavLink, NavLinkDiv, NavHREF, LogoLink } from './styles';
+import { NavLinkDiv, NavHREF, LogoLink } from './styles';
 
 export const NeoNavBar = withTheme(
   ({

--- a/vizhub-v2/packages/neoFrontend/src/pages/HomePage/index.js
+++ b/vizhub-v2/packages/neoFrontend/src/pages/HomePage/index.js
@@ -8,7 +8,7 @@ import { useVizzesSort } from '../../VizzesGrid/VizzesSortForm';
 import { Wrapper, Content } from '../styles';
 import { HomePageDataProvider } from './HomePageDataContext';
 import { Vizzes } from './Vizzes';
-import { Banner } from './Banner';
+//import { Banner } from './Banner';
 import { Sort } from './Sort';
 import { HtmlStylesOverride } from './styles';
 
@@ -24,7 +24,14 @@ export const HomePage = () => {
       <HtmlStylesOverride />
       <HomePageDataProvider sort={sort} fallback={<LoadingScreen />}>
         <NavBar isHomePage={true} showSearch />
-        <Banner />
+        {
+          // The thing at the top that says
+          // "You're minutes away from creating a data visualization."
+          // Removed as not required. Let the content speak for itself.
+          // "Get started" CTA not required, as users will end up there after
+          // logging in and noticing "Create viz" in the user dropdown.
+          // <Banner />
+        }
         <Wrapper>
           <Content>
             {showSortOptions ? (


### PR DESCRIPTION
This PR removes the thing at the top that says
"You're minutes away from creating a data visualization."
Removed as not required. Let the content speak for itself.
"Get started" CTA not required, as users will end up there after
logging in and noticing "Create viz" in the user dropdown.

![image](https://user-images.githubusercontent.com/68416/146484326-50ce5af2-c41c-4a03-b261-54d4529be30f.png)
