### PR TITLE
Fix error with updating viz with no index.js

### DIFF
--- a/vizhub-v2/packages/neoFrontend/src/pages/VizPage/RunContext/updateBundleIfNeeded.js
+++ b/vizhub-v2/packages/neoFrontend/src/pages/VizPage/RunContext/updateBundleIfNeeded.js
@@ -32,7 +32,10 @@ export const updateBundleIfNeeded = async (
         submitVizContentOp(fileCreateOp(files, { name: 'bundle.js', text }));
       }
     } else {
-      submitVizContentOp(deleteFileOp(viz, 'bundle.js'));
+      const bundleJSExists = getFileIndex(files, 'bundle.js') !== -1;
+      if (bundleJSExists) {
+        submitVizContentOp(deleteFileOp(viz, 'bundle.js'));
+      }
     }
   }
 };


### PR DESCRIPTION
This PR fixes a glitch that happens when repeatedly updating a viz that does _not_ have an `index.js`.

Bug first observed here https://vizhub.com/alark/290a1c583f024d01b7a852d12fefbf94

The error looks like this.

![image](https://user-images.githubusercontent.com/68416/154266349-67b41e0c-05a1-4625-b5d3-1155949b1d58.png)

It was happening because the runner logic was trying to delete `bundle.js`, but `bundle.js` did not exist.

This PR makes it so that the runner logic only attempts to delete `bundle.js` if it exists.